### PR TITLE
add catalog-info file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,8 +4,9 @@ metadata:
   name: espressione
   description: Gema que fornece padrões regex úteis.
   annotations:
+    circleci.com/project-slug: github/ResultadosDigitais/espressione
     github.com/project-slug: ResultadosDigitais/espressione
 spec:
-  type: service
+  type: library
   owner: devtools
   lifecycle: production 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: espressione
+  description: Gema que fornece padrões regex úteis.
+  annotations:
+    github.com/project-slug: ResultadosDigitais/espressione
+spec:
+  type: service
+  owner: devtools
+  lifecycle: production 


### PR DESCRIPTION
Contexto

Estamos mapeando os componentes do plataform para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente para que ele seja refletido no Backstage.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md